### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ABReviewReminder.appLaunched()
 
 Simply add the following lines to your `Podfile`:
 ```ruby
-# required by Cocoapods 0.36.0.rc.1 for Swift Pods
+# required by CocoaPods 0.36.0.rc.1 for Swift Pods
 use_frameworks! 
 
 pod 'ABReviewReminder', '~> 1.0'
@@ -145,7 +145,7 @@ pod 'ABReviewReminder', '~> 1.0'
 
 ##ToDo list
 - [x] Project example (double click on `Example/MyAwesomeApp/MyAwesomeApp.xcworkspace`)
-- [x] Cocoapods support
+- [x] CocoaPods support
 
 ##Requirements
 - iOS 8.0


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
